### PR TITLE
make settins query happen only on client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stop doing private queries on SSR and avoid breaking SSR.
 
 ## [1.1.2] - 2020-04-28
 

--- a/react/RatingInline.tsx
+++ b/react/RatingInline.tsx
@@ -17,7 +17,7 @@ declare var yotpo: any
 const RatingInline: FunctionComponent<BlockClass> = props => {
   const { blockClass } = props
   const { product }: ProductContext = useContext(ProductSummaryContext)
-  const { data } = useQuery(Settings)
+  const { data } = useQuery(Settings, { ssr: false })
   const baseClassNames = generateBlockClass(
     styles.ratingInlineContainer,
     blockClass

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -16,7 +16,7 @@ declare var yotpo: any
 const RatingSummary: FunctionComponent<BlockClass> = props => {
   const { blockClass } = props
   const { product }: ProductContext = useContext(ProductContext)
-  const { data } = useQuery(Settings)
+  const { data } = useQuery(Settings, { ssr: false })
 
   const baseClassNames = generateBlockClass(
     styles.ratingSummaryContainer,

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -16,7 +16,7 @@ declare var yotpo: any
 const Reviews: FunctionComponent<BlockClass> = props => {
   const { blockClass } = props
   const { product }: ProductContext = useContext(ProductContext)
-  const { data } = useQuery(Settings)
+  const { data } = useQuery(Settings, { ssr: false })
   const baseClassNames = generateBlockClass(styles.reviewsContainer, blockClass)
 
   useEffect(() => {


### PR DESCRIPTION
**What problem is this solving?**

wwg search pages were throwing errors, because a component was doing private query during SSR, which is not allowed

**How should this be manually tested?**
https://fidelis--worldwidegolf.myvtex.com/shoes/spiked-shoes

this should be ok
**Screenshots or example usage:**