### PR TITLE
Implement debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Implemented debounce to streamline `refreshWidgets()` calls
+
 ## [1.1.4] - 2020-05-27
 
 ### Changed
@@ -14,7 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enabling SSR components
 
 ## [1.1.3] - 2020-05-11
+
 ### Fixed
+
 - Stop doing private queries on SSR and avoid breaking SSR.
 
 ## [1.1.2] - 2020-04-28

--- a/react/RatingInline.tsx
+++ b/react/RatingInline.tsx
@@ -9,18 +9,19 @@ import { ProductSummaryContext } from 'vtex.product-summary'
 import { ProductContext } from 'vtex.product-context'
 import { generateBlockClass, BlockClass } from '@vtex/css-handles'
 import styles from './styles.css'
+import { refresh } from './utils'
 
-declare var global: {
+declare const global: {
   __hostname__: string
   __pathname__: string
 }
 
-declare var yotpo: any
+declare const yotpo: any
 
 window.loading = new Promise(function(resolve) {
   setTimeout(function() {
     resolve()
-  }, 100)
+  }, 1)
 })
 
 const RatingInline: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
@@ -29,14 +30,20 @@ const RatingInline: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
     styles.ratingInlineContainer,
     blockClass
   )
-  const [useRefId, setUseRefId] = useState(false)
+  const [useRefId, setUseRefId] = useState(null)
 
   useEffect(() => {
-    if (typeof yotpo != 'undefined' && yotpo.initialized && product)
-      setTimeout(function() {
-        yotpo.refreshWidgets()
-      }, 1000)
-  }, [product])
+    if (
+      typeof yotpo != 'undefined' &&
+      yotpo.initialized &&
+      product &&
+      useRefId !== null
+    ) {
+      // setTimeout(function() {
+      refresh()
+    }
+    // }, 1000)
+  }, [product, useRefId])
 
   useEffect(() => {
     window.loading.then(() => {
@@ -48,7 +55,7 @@ const RatingInline: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
     })
   }, [])
 
-  if (!product) return null
+  if (!product || useRefId === null) return null
 
   const getLocation = () =>
     canUseDOM

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -8,17 +8,18 @@ import { canUseDOM } from 'vtex.render-runtime'
 import { ProductContext } from 'vtex.product-context'
 import { generateBlockClass, BlockClass } from '@vtex/css-handles'
 import styles from './styles.css'
+import { refresh } from './utils'
 
-declare var global: {
+declare const global: {
   __hostname__: string
   __pathname__: string
 }
-declare var yotpo: any
+declare const yotpo: any
 
 window.loading = new Promise(function(resolve) {
   setTimeout(function() {
     resolve()
-  }, 100)
+  }, 1)
 })
 
 const RatingSummary: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
@@ -27,14 +28,21 @@ const RatingSummary: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
     styles.ratingSummaryContainer,
     blockClass
   )
-  const [useRefId, setUseRefId] = useState(false)
+  const [useRefId, setUseRefId] = useState(null)
 
   useEffect(() => {
-    if (typeof yotpo != 'undefined' && yotpo.initialized && product)
-      setTimeout(function() {
-        yotpo.refreshWidgets()
-      }, 1000)
-  }, [product])
+    if (
+      typeof yotpo != 'undefined' &&
+      yotpo.initialized &&
+      product &&
+      useRefId !== null
+    ) {
+      // setTimeout(function() {
+      refresh()
+    }
+    // }, 1000)
+  }, [product, useRefId])
+
   useEffect(() => {
     window.loading.then(() => {
       setUseRefId(
@@ -44,7 +52,9 @@ const RatingSummary: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
       )
     })
   }, [])
-  if (!product) return null
+
+  if (!product || useRefId === null) return null
+
   const getLocation = () =>
     canUseDOM
       ? {

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -8,31 +8,38 @@ import { canUseDOM } from 'vtex.render-runtime'
 import { ProductContext } from 'vtex.product-context'
 import { generateBlockClass, BlockClass } from '@vtex/css-handles'
 import styles from './styles.css'
+import { refresh } from './utils'
 
-declare var global: {
+declare const global: {
   __hostname__: string
   __pathname__: string
 }
 
-declare var yotpo: any
+declare const yotpo: any
 
 window.loading = new Promise(function(resolve) {
   setTimeout(function() {
     resolve()
-  }, 100)
+  }, 1)
 })
 
 const Reviews: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
   const { product }: ProductContext = useContext(ProductContext)
   const baseClassNames = generateBlockClass(styles.reviewsContainer, blockClass)
-  const [useRefId, setUseRefId] = useState(false)
+  const [useRefId, setUseRefId] = useState(null)
 
   useEffect(() => {
-    if (typeof yotpo != 'undefined' && yotpo.initialized && product)
-      setTimeout(function() {
-        yotpo.refreshWidgets()
-      }, 1000)
-  }, [product])
+    if (
+      typeof yotpo != 'undefined' &&
+      yotpo.initialized &&
+      product &&
+      useRefId !== null
+    ) {
+      // setTimeout(function() {
+      refresh()
+    }
+    // }, 1000)
+  }, [product, useRefId])
 
   useEffect(() => {
     window.loading.then(() => {
@@ -44,7 +51,7 @@ const Reviews: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
     })
   }, [])
 
-  if (!product) return null
+  if (!product || useRefId === null) return null
 
   const getLocation = () =>
     canUseDOM

--- a/react/package.json
+++ b/react/package.json
@@ -10,6 +10,7 @@
     "apollo-link": "^1.2.13",
     "apollo-utilities": "^1.3.3",
     "classnames": "^2.2.6",
+    "debounce": "^1.2.0",
     "ramda": "^0.26.1",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",
+    "@types/debounce": "^1.2.0",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.7",
     "@types/prop-types": "^15.7.0",

--- a/react/utils/index.tsx
+++ b/react/utils/index.tsx
@@ -1,0 +1,8 @@
+import { debounce } from 'debounce'
+
+declare const yotpo: any
+
+function refreshWidgets() {
+  yotpo.refreshWidgets()
+}
+export const refresh = debounce(refreshWidgets, 1000)

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1082,6 +1082,11 @@
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
   integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
 
+"@types/debounce@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
+  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1887,6 +1892,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
**What problem is this solving?**

Prior to this PR, every Yotpo component was calling `yotpo.refreshWidgets()` to make sure the Yotpo widgets refreshed after React navigation. This PR implements `debounce` so that the refresh calls are consolidated into a single execution. 

**How should this be manually tested?**

New version linked here: https://debounce--worldwidegolf.myvtex.com/bushnell-hybrid-rangefinder-10143757/p 
Check network tab and filter by Yotpo. Compare with https://yotposeo--worldwidegolf.myvtex.com/bushnell-hybrid-rangefinder-10143757/p