### PR TITLE
Export and use useRefId setting via prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Uses settings from `appSettings` prop, which allows rendering on SSR.
+
+### Fixed
+- Issue where search engines were timing out before getting rich results data.
 
 ## [1.1.5] - 2020-05-29
 

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,8 @@
       "useRefId": {
         "title": "Use Reference Id",
         "description": "Use reference Id rather than product id to link reviews to products",
-        "type": "boolean"
+        "type": "boolean",
+        "access": "public"
       }
     }
   },

--- a/react/RatingInline.tsx
+++ b/react/RatingInline.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import React, { FunctionComponent, useContext, useEffect } from 'react'
 import { canUseDOM } from 'vtex.render-runtime'
 import { ProductSummaryContext } from 'vtex.product-summary'
 import { ProductContext } from 'vtex.product-context'
@@ -24,13 +19,16 @@ window.loading = new Promise(function(resolve) {
   }, 1)
 })
 
-const RatingInline: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
+const RatingInline: FunctionComponent<BlockClass> = ({
+  blockClass,
+  appSettings,
+}: any) => {
   const { product }: ProductContext = useContext(ProductSummaryContext)
   const baseClassNames = generateBlockClass(
     styles.ratingInlineContainer,
     blockClass
   )
-  const [useRefId, setUseRefId] = useState(null)
+  const { useRefId } = appSettings
 
   useEffect(() => {
     if (
@@ -44,16 +42,6 @@ const RatingInline: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
     }
     // }, 1000)
   }, [product, useRefId])
-
-  useEffect(() => {
-    window.loading.then(() => {
-      setUseRefId(
-        window?.yotpoApp?.useRefIdSetting
-          ? JSON.parse(window.yotpoApp.useRefIdSetting)
-          : false
-      )
-    })
-  }, [])
 
   if (!product || useRefId === null) return null
 

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import React, { FunctionComponent, useContext, useEffect } from 'react'
 import { canUseDOM } from 'vtex.render-runtime'
 import { ProductContext } from 'vtex.product-context'
 import { generateBlockClass, BlockClass } from '@vtex/css-handles'
@@ -16,19 +11,16 @@ declare const global: {
 }
 declare const yotpo: any
 
-window.loading = new Promise(function(resolve) {
-  setTimeout(function() {
-    resolve()
-  }, 1)
-})
-
-const RatingSummary: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
+const RatingSummary: FunctionComponent<BlockClass> = ({
+  blockClass,
+  appSettings,
+}: any) => {
   const { product }: ProductContext = useContext(ProductContext)
   const baseClassNames = generateBlockClass(
     styles.ratingSummaryContainer,
     blockClass
   )
-  const [useRefId, setUseRefId] = useState(null)
+  const { useRefId } = appSettings
 
   useEffect(() => {
     if (
@@ -42,16 +34,6 @@ const RatingSummary: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
     }
     // }, 1000)
   }, [product, useRefId])
-
-  useEffect(() => {
-    window.loading.then(() => {
-      setUseRefId(
-        window?.yotpoApp?.useRefIdSetting
-          ? JSON.parse(window.yotpoApp.useRefIdSetting)
-          : false
-      )
-    })
-  }, [])
 
   if (!product || useRefId === null) return null
 

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import React, { FunctionComponent, useContext, useEffect } from 'react'
 import { canUseDOM } from 'vtex.render-runtime'
 import { ProductContext } from 'vtex.product-context'
 import { generateBlockClass, BlockClass } from '@vtex/css-handles'
@@ -23,10 +18,13 @@ window.loading = new Promise(function(resolve) {
   }, 1)
 })
 
-const Reviews: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
+const Reviews: FunctionComponent<BlockClass> = ({
+  blockClass,
+  appSettings,
+}: any) => {
   const { product }: ProductContext = useContext(ProductContext)
   const baseClassNames = generateBlockClass(styles.reviewsContainer, blockClass)
-  const [useRefId, setUseRefId] = useState(null)
+  const { useRefId } = appSettings
 
   useEffect(() => {
     if (
@@ -40,16 +38,6 @@ const Reviews: FunctionComponent<BlockClass> = ({ blockClass }: any) => {
     }
     // }, 1000)
   }, [product, useRefId])
-
-  useEffect(() => {
-    window.loading.then(() => {
-      setUseRefId(
-        window?.yotpoApp?.useRefIdSetting
-          ? JSON.parse(window.yotpoApp.useRefIdSetting)
-          : false
-      )
-    })
-  }, [])
 
   if (!product || useRefId === null) return null
 


### PR DESCRIPTION
**What problem is this solving?**
Get useRefId setting from appSettings prop, to fix issue with SSR

Depends on
https://github.com/vtex/render-server/pull/629
https://github.com/vtex-apps/render-runtime/pull/533/
https://github.com/vtex/pixel-server/pull/35

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**
https://lbebber--worldwidegolf.myvtex.com/bushnell-hybrid-rangefinder-10143757/p

Go to "view source" (cmd opt U on chrome on macOS) and look for `data-product-id`. This shows that the review info is being rendered on SSR
**Screenshots or example usage:**